### PR TITLE
Link C++

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ links = "snappy"
 [features]
 bindgen = ["dep:bindgen"]
 
+[dependencies]
+link-cplusplus = { version = "1.0.9" }
+
 [build-dependencies]
 bindgen = { version = "0.69.4", optional = true }
 cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -90,7 +90,7 @@ fn generate_bindings() {
 fn main() {
     // println!("cargo:rerun-if-changed=build.rs");
     // println!("cargo:rerun-if-changed=snappy");
-    println!("cargo:rustc-link-lib=snappy");
+    println!("cargo:rustc-link-lib=static=snappy");
 
     let dst = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```bash
 //! cargo build --features bindgen
 //! ```
-//! 
+//!
 //! ## Licence
 //! `snappy_src` is licensed under either of
 //!  - the Apache License, Version 2.0 [LICENSE-APACHE](./LICENCE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0> or
@@ -18,5 +18,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+
+extern crate link_cplusplus;
 
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/bindings.rs"));


### PR DESCRIPTION
The library requires c++ stdlib, which is on some platforms not included by default