### PR TITLE
Make sure cc/Build::std is available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ bindgen = ["dep:bindgen"]
 
 [build-dependencies]
 bindgen = { version = "0.69.4", optional = true }
-cc = "1.0"
+cc = "1.0.99"
 # regex = "1"
 # cmake = "0.1"


### PR DESCRIPTION
Noticed this function was not available on the `cc` that was specified in my `Cargo.lock`